### PR TITLE
Build on 3.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
     - pip
     - cython
-    - numpy 1.11.*
+    - numpy >=1.14
     - model_metadata
     - prms
     - prms_surface

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pymt_prms_surface" %}
 {% set version = "0.1.2" %}
-{% set build_number = "1" %}
+{% set build_number = "2" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
This PR updates the requirement for numpy to allow builds on Python 3.8.