### PR TITLE
Fix broken build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,15 @@ install:
   - export PATH="$CONDA_PREFIX/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda install python=$TRAVIS_PYTHON_VERSION -c conda-forge
-  - conda install -q conda-build anaconda-client -c conda-forge
+  - conda config --set channel_priority strict
+  - conda config --add channels csdms-stack
+  - conda config --add channels conda-forge
+  - conda install python=$TRAVIS_PYTHON_VERSION conda-build anaconda-client
+  - conda info -a
 
 script:
-  - conda build ./recipe -c conda-forge -c csdms-stack --old-build-string
+  - conda build ./recipe
 
 after_success:
   - curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py > $HOME/anaconda_upload.py
-  - echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack --old-build-string --token=-
+  - echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack --token=-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,19 +16,20 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ compiler('fortran') }}
+    - libnetcdf
+    - netcdf-fortran
   host:
     - python
-    - pip
     - cython
     - numpy >=1.14
-    - model_metadata
+    - bmi-fortran
     - prms
     - prms_surface
   run:
     - python
     - {{ pin_compatible('numpy') }}
+    - bmi-fortran
     - prms
     - prms_surface
 


### PR DESCRIPTION
This PR updates the conda recipe to escape dependency hell.

What I think happened was:

1. `prms_surface -> prms -> coretran`
1. `coretran` is built with `gfortran` 7.5
1. `gfortran` 9.3 is now the default

and this led to library incompatibilities.

By including `libnetcdf` and `netcdf-fortran` in the build dependencies, the older `gfortran` is installed, and everything happily builds.